### PR TITLE
Add FlashBriefing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ _testmain.go
 *.exe
 *.test
 *.prof
+
+.idea

--- a/alexa.go
+++ b/alexa.go
@@ -1,0 +1,3 @@
+// Package alexa provides base types, functions and utilities for implementing functionality that
+// can be used by Amazon Alexa Services
+package alexa

--- a/flash_briefing.go
+++ b/flash_briefing.go
@@ -45,7 +45,7 @@ type FlashBriefing struct {
 
 // MarshalJSON is a convenience function which manipulates the FlashBriefing into the JSON format expected by Alexa
 func (briefing *FlashBriefing) MarshalJSON() ([]byte, error) {
-	var interfaceSlice []interface{} = make([]interface{}, len(briefing.Items))
+	var interfaceSlice = make([]interface{}, len(briefing.Items))
 	for i, item := range briefing.Items {
 		interfaceSlice[i] = item
 	}

--- a/flash_briefing.go
+++ b/flash_briefing.go
@@ -1,0 +1,66 @@
+package alexa
+
+import (
+	"encoding/json"
+	"net/http"
+	"time"
+)
+
+const (
+	contentHeader   = `Content-Type`
+	jsonContentType = `application/json`
+)
+
+// FlashBriefingItem is a representation of an item in an Alexa Flash Briefing.
+type FlashBriefingItem struct {
+	// Unique identifier for each feed item. UUID format preferred. This field is required for the feed
+	ID string `json:"uid" xml:"guid"`
+	// Indicates freshness of feed item, and used to order items to be read or played from newest to oldest. Note
+	// that older items may not be played or read. This field is required for the feed
+	Date time.Time `json:"updateDate" xml:"pubDate"`
+	// The title of the feed item to display in the Alexa app. This field is required for the feed
+	Title string `json:"titleText" xml:"title"`
+	// For text feeds, the text that is read to the customer. This field is required for the feed, but may be an
+	// empty string. Each feed item is currently limited to 4500 characters, and will be truncated if it exceeds
+	// this length. The truncation will occur at the nearest full sentence below 4500 characters. The string should
+	// be plain text and not contain special characters such as SSML, HTML or XML tags. The text should be properly
+	// punctuated, short, and easily understood when read aloud. Commas (,) and semicolons (;) result in short
+	// pauses. Periods (.), question marks (?) and exclamation points (!) result in longer pauses. Avoid using
+	// non-standard punctuation as it could cause text to speech issues.
+	Text string `json:"mainText" xml:"description"`
+	// HTTPS URL specifying the location of audio content for an audio feed. An audio item must contain a HTTPS URL
+	// to audio content. The audio content should be 256kbps mono or stereo MP3. Content should not exceed 10
+	// minutes in length. Program loudness should be -14 dB LUFS/LKFS. Alternatively, if not using LUFS or LKFS,
+	// loudness should target a Total RMS value between -15 to -13 dB. The true-peak value should not exceed –2 dBFS
+	AudioURL string `json:"streamUrl" xml:"enclosure"`
+	// Provides the URL target for the Read More link in the Alexa app. This field is optional for the feed
+	DisplayURL string `json:"redirectionUrl" xml:"link"`
+}
+
+// A FlashBriefing provides audio or text content for a Flash Briefing skill. Alexa either plays or reads the feed
+// contents to a customer.
+type FlashBriefing struct {
+	Items []*FlashBriefingItem
+}
+
+// MarshalJSON is a convenience function which manipulates the FlashBriefing into the JSON format expected by Alexa
+func (briefing *FlashBriefing) MarshalJSON() ([]byte, error) {
+	var interfaceSlice []interface{} = make([]interface{}, len(briefing.Items))
+	for i, item := range briefing.Items {
+		interfaceSlice[i] = item
+	}
+	return json.Marshal(interfaceSlice)
+}
+
+// FlashBriefingHandler takes a pointer to a FlashBriefing and returns a HttpHandler which will respond to a HttpRequest
+// with the FlashBriefing converted into JSON and appropriate response headers set
+func FlashBriefingHandler(briefing *FlashBriefing) http.HandlerFunc {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		w.Header().Add(contentHeader, jsonContentType)
+		if data, err := json.Marshal(briefing); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		} else {
+			w.Write(data)
+		}
+	})
+}

--- a/flash_briefing.go
+++ b/flash_briefing.go
@@ -14,12 +14,12 @@ const (
 // FlashBriefingItem is a representation of an item in an Alexa Flash Briefing.
 type FlashBriefingItem struct {
 	// Unique identifier for each feed item. UUID format preferred. This field is required for the feed
-	ID string `json:"uid" xml:"guid"`
+	ID string `json:"uid"`
 	// Indicates freshness of feed item, and used to order items to be read or played from newest to oldest. Note
 	// that older items may not be played or read. This field is required for the feed
-	Date time.Time `json:"updateDate" xml:"pubDate"`
+	Date time.Time `json:"updateDate"`
 	// The title of the feed item to display in the Alexa app. This field is required for the feed
-	Title string `json:"titleText" xml:"title"`
+	Title string `json:"titleText"`
 	// For text feeds, the text that is read to the customer. This field is required for the feed, but may be an
 	// empty string. Each feed item is currently limited to 4500 characters, and will be truncated if it exceeds
 	// this length. The truncation will occur at the nearest full sentence below 4500 characters. The string should
@@ -27,14 +27,14 @@ type FlashBriefingItem struct {
 	// punctuated, short, and easily understood when read aloud. Commas (,) and semicolons (;) result in short
 	// pauses. Periods (.), question marks (?) and exclamation points (!) result in longer pauses. Avoid using
 	// non-standard punctuation as it could cause text to speech issues.
-	Text string `json:"mainText" xml:"description"`
+	Text string `json:"mainText,omitempty"`
 	// HTTPS URL specifying the location of audio content for an audio feed. An audio item must contain a HTTPS URL
 	// to audio content. The audio content should be 256kbps mono or stereo MP3. Content should not exceed 10
 	// minutes in length. Program loudness should be -14 dB LUFS/LKFS. Alternatively, if not using LUFS or LKFS,
 	// loudness should target a Total RMS value between -15 to -13 dB. The true-peak value should not exceed –2 dBFS
-	AudioURL string `json:"streamUrl" xml:"enclosure"`
+	AudioURL string `json:"streamUrl,omitempty"`
 	// Provides the URL target for the Read More link in the Alexa app. This field is optional for the feed
-	DisplayURL string `json:"redirectionUrl" xml:"link"`
+	DisplayURL string `json:"redirectionUrl,omitempty"`
 }
 
 // A FlashBriefing provides audio or text content for a Flash Briefing skill. Alexa either plays or reads the feed

--- a/flash_briefing_test.go
+++ b/flash_briefing_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
@@ -18,8 +19,8 @@ const (
 	demoText        = "Main information for the item"
 	demoStream      = "https://developer.amazon.com/public/community/blog/myaudiofile.mp3"
 	demoRedirection = "https://developer.amazon.com/public/community/blog"
-
-	demoJSON = `{"uid":"%s","updateDate":"%s","titleText":"%s","mainText":"%s","streamUrl":"%s","redirectionUrl":"%s"}`
+	demoJSON        = `{"uid":"%s","updateDate":"%s","titleText":"%s","mainText":"%s","streamUrl":"%s","redirectionUrl":"%s"}`
+	max_items       = 5
 )
 
 var expectedJSON = fmt.Sprintf(demoJSON, demoUID, demoDate, demoTitle, demoText, demoStream, demoRedirection)
@@ -149,4 +150,23 @@ func TestServeFlashBriefing(t *testing.T) {
 			})
 		})
 	})
+}
+
+func ExampleFlashBriefingHandler() {
+	items := make([]*FlashBriefingItem, max_items)
+	briefing := &FlashBriefing{
+		Items: items,
+	}
+
+	for i := 0; i < max_items; i++ {
+		briefing.Items[i] = &FlashBriefingItem{
+			ID:    fmt.Sprintf(`id-%d`, i),
+			Date:  time.Now(),
+			Title: fmt.Sprintf(`Demo Entry %d`, i),
+			Text:  fmt.Sprintf(`This is the entry for %d`, i),
+		}
+	}
+
+	http.HandleFunc(`/`, FlashBriefingHandler(briefing))
+	http.ListenAndServe(`:8080`, nil)
 }

--- a/flash_briefing_test.go
+++ b/flash_briefing_test.go
@@ -12,33 +12,32 @@ import (
 )
 
 const (
-	demo_uid         = "urn:uuid:1335c695-cfb8-4ebb-abbd-80da344efa6b"
-	demo_date        = "2016-05-23T22:34:51Z"
-	demo_title       = "Amazon Developer Blog, week in review May 23rd"
-	demo_text        = "Main information for the item"
-	demo_stream      = "https://developer.amazon.com/public/community/blog/myaudiofile.mp3"
-	demo_redirection = "https://developer.amazon.com/public/community/blog"
+	demoUID         = "urn:uuid:1335c695-cfb8-4ebb-abbd-80da344efa6b"
+	demoDate        = "2016-05-23T22:34:51Z"
+	demoTitle       = "Amazon Developer Blog, week in review May 23rd"
+	demoText        = "Main information for the item"
+	demoStream      = "https://developer.amazon.com/public/community/blog/myaudiofile.mp3"
+	demoRedirection = "https://developer.amazon.com/public/community/blog"
 
-	demo_json = `{"uid":"%s","updateDate":"%s","titleText":"%s","mainText":"%s","streamUrl":"%s","redirectionUrl":"%s"}`
+	demoJSON = `{"uid":"%s","updateDate":"%s","titleText":"%s","mainText":"%s","streamUrl":"%s","redirectionUrl":"%s"}`
 )
 
-var expected_json = fmt.Sprintf(demo_json, demo_uid, demo_date, demo_title, demo_text,
-	demo_stream, demo_redirection)
+var expectedJSON = fmt.Sprintf(demoJSON, demoUID, demoDate, demoTitle, demoText, demoStream, demoRedirection)
 
 func TestFlashBriefingItem_MarshalJSON(t *testing.T) {
 	Convey(`Given I have a FlashBriefingItem`, t, func() {
-		date, err := time.Parse(time.RFC3339, demo_date)
+		date, err := time.Parse(time.RFC3339, demoDate)
 		if err != nil {
 			panic(err)
 		}
 
 		item := &FlashBriefingItem{
-			ID:         demo_uid,
+			ID:         demoUID,
 			Date:       date,
-			Title:      demo_title,
-			Text:       demo_text,
-			AudioURL:   demo_stream,
-			DisplayURL: demo_redirection,
+			Title:      demoTitle,
+			Text:       demoText,
+			AudioURL:   demoStream,
+			DisplayURL: demoRedirection,
 		}
 
 		Convey(`When I marshal the item to JSON`, func() {
@@ -49,27 +48,26 @@ func TestFlashBriefingItem_MarshalJSON(t *testing.T) {
 			})
 
 			Convey(`Then the correct json will be produced`, func() {
-				So(string(data), ShouldEqual, expected_json)
+				So(string(data), ShouldEqual, expectedJSON)
 			})
 		})
 	})
-
 }
 
 func TestFlashBriefing_MarshalJSON(t *testing.T) {
 	Convey(`Given I have a FlashBriefingItem`, t, func() {
-		date, err := time.Parse(time.RFC3339, demo_date)
+		date, err := time.Parse(time.RFC3339, demoDate)
 		if err != nil {
 			panic(err)
 		}
 
 		item := &FlashBriefingItem{
-			ID:         demo_uid,
+			ID:         demoUID,
 			Date:       date,
-			Title:      demo_title,
-			Text:       demo_text,
-			AudioURL:   demo_stream,
-			DisplayURL: demo_redirection,
+			Title:      demoTitle,
+			Text:       demoText,
+			AudioURL:   demoStream,
+			DisplayURL: demoRedirection,
 		}
 
 		Convey(`And I populate a FlashBriefing with that item`, func() {
@@ -88,10 +86,8 @@ func TestFlashBriefing_MarshalJSON(t *testing.T) {
 				})
 
 				Convey(`Then the correct json will be produced`, func() {
-					expected_item := fmt.Sprintf(demo_json, demo_uid, demo_date, demo_title, demo_text,
-						demo_stream, demo_redirection)
-					expected_json := fmt.Sprintf(`[%s,%s]`, expected_item, expected_item)
-					So(string(data), ShouldEqual, expected_json)
+					expectedBriefing := fmt.Sprintf(`[%s,%s]`, expectedJSON, expectedJSON)
+					So(string(data), ShouldEqual, expectedBriefing)
 				})
 			})
 		})
@@ -100,18 +96,18 @@ func TestFlashBriefing_MarshalJSON(t *testing.T) {
 
 func TestServeFlashBriefing(t *testing.T) {
 	Convey(`Given I have a FlashBriefingItem`, t, func() {
-		date, err := time.Parse(time.RFC3339, demo_date)
+		date, err := time.Parse(time.RFC3339, demoDate)
 		if err != nil {
 			panic(err)
 		}
 
 		item := &FlashBriefingItem{
-			ID:         demo_uid,
+			ID:         demoUID,
 			Date:       date,
-			Title:      demo_title,
-			Text:       demo_text,
-			AudioURL:   demo_stream,
-			DisplayURL: demo_redirection,
+			Title:      demoTitle,
+			Text:       demoText,
+			AudioURL:   demoStream,
+			DisplayURL: demoRedirection,
 		}
 
 		Convey(`And I populate a FlashBriefing with that item`, func() {
@@ -142,16 +138,14 @@ func TestServeFlashBriefing(t *testing.T) {
 							if err != nil {
 								panic(err)
 							}
-							expectedJson, err := json.Marshal(briefing)
+							marshaledJSON, err := json.Marshal(briefing)
 							if err != nil {
 								panic(err)
 							}
-							So(body, ShouldResemble, expectedJson)
+							So(body, ShouldResemble, marshaledJSON)
 						})
 					})
-
 				})
-
 			})
 		})
 	})

--- a/flash_briefing_test.go
+++ b/flash_briefing_test.go
@@ -1,0 +1,158 @@
+package alexa
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+const (
+	demo_uid         = "urn:uuid:1335c695-cfb8-4ebb-abbd-80da344efa6b"
+	demo_date        = "2016-05-23T22:34:51Z"
+	demo_title       = "Amazon Developer Blog, week in review May 23rd"
+	demo_text        = "Main information for the item"
+	demo_stream      = "https://developer.amazon.com/public/community/blog/myaudiofile.mp3"
+	demo_redirection = "https://developer.amazon.com/public/community/blog"
+
+	demo_json = `{"uid":"%s","updateDate":"%s","titleText":"%s","mainText":"%s","streamUrl":"%s","redirectionUrl":"%s"}`
+)
+
+var expected_json = fmt.Sprintf(demo_json, demo_uid, demo_date, demo_title, demo_text,
+	demo_stream, demo_redirection)
+
+func TestFlashBriefingItem_MarshalJSON(t *testing.T) {
+	Convey(`Given I have a FlashBriefingItem`, t, func() {
+		date, err := time.Parse(time.RFC3339, demo_date)
+		if err != nil {
+			panic(err)
+		}
+
+		item := &FlashBriefingItem{
+			ID:         demo_uid,
+			Date:       date,
+			Title:      demo_title,
+			Text:       demo_text,
+			AudioURL:   demo_stream,
+			DisplayURL: demo_redirection,
+		}
+
+		Convey(`When I marshal the item to JSON`, func() {
+			data, err := json.Marshal(item)
+
+			Convey(`Then the error will be nil`, func() {
+				So(err, ShouldBeNil)
+			})
+
+			Convey(`Then the correct json will be produced`, func() {
+				So(string(data), ShouldEqual, expected_json)
+			})
+		})
+	})
+
+}
+
+func TestFlashBriefing_MarshalJSON(t *testing.T) {
+	Convey(`Given I have a FlashBriefingItem`, t, func() {
+		date, err := time.Parse(time.RFC3339, demo_date)
+		if err != nil {
+			panic(err)
+		}
+
+		item := &FlashBriefingItem{
+			ID:         demo_uid,
+			Date:       date,
+			Title:      demo_title,
+			Text:       demo_text,
+			AudioURL:   demo_stream,
+			DisplayURL: demo_redirection,
+		}
+
+		Convey(`And I populate a FlashBriefing with that item`, func() {
+			briefing := &FlashBriefing{
+				Items: []*FlashBriefingItem{
+					item,
+					item,
+				},
+			}
+
+			Convey(`When I marshal the briefing to JSON`, func() {
+				data, err := json.Marshal(briefing)
+
+				Convey(`Then the error will be nil`, func() {
+					So(err, ShouldBeNil)
+				})
+
+				Convey(`Then the correct json will be produced`, func() {
+					expected_item := fmt.Sprintf(demo_json, demo_uid, demo_date, demo_title, demo_text,
+						demo_stream, demo_redirection)
+					expected_json := fmt.Sprintf(`[%s,%s]`, expected_item, expected_item)
+					So(string(data), ShouldEqual, expected_json)
+				})
+			})
+		})
+	})
+}
+
+func TestServeFlashBriefing(t *testing.T) {
+	Convey(`Given I have a FlashBriefingItem`, t, func() {
+		date, err := time.Parse(time.RFC3339, demo_date)
+		if err != nil {
+			panic(err)
+		}
+
+		item := &FlashBriefingItem{
+			ID:         demo_uid,
+			Date:       date,
+			Title:      demo_title,
+			Text:       demo_text,
+			AudioURL:   demo_stream,
+			DisplayURL: demo_redirection,
+		}
+
+		Convey(`And I populate a FlashBriefing with that item`, func() {
+			briefing := &FlashBriefing{
+				Items: []*FlashBriefingItem{
+					item,
+					item,
+				},
+			}
+
+			Convey(`And I have a http handler`, func() {
+				handler := FlashBriefingHandler(briefing)
+
+				Convey(`And I have a HTTP request`, func() {
+					req := httptest.NewRequest("GET", `/`, nil)
+
+					Convey(`When I make the request`, func() {
+						w := httptest.NewRecorder()
+
+						handler.ServeHTTP(w, req)
+
+						Convey(`Then the response will have the appropriate Content-Type`, func() {
+							So(w.HeaderMap.Get(contentHeader), ShouldEqual, jsonContentType)
+						})
+
+						Convey(`Then the body will be the FlashBriefing as JSON`, func() {
+							body, err := ioutil.ReadAll(w.Body)
+							if err != nil {
+								panic(err)
+							}
+							expectedJson, err := json.Marshal(briefing)
+							if err != nil {
+								panic(err)
+							}
+							So(body, ShouldResemble, expectedJson)
+						})
+					})
+
+				})
+
+			})
+		})
+	})
+}


### PR DESCRIPTION
Create the relevant types for use for a [Flash Briefing](https://developer.amazon.com/public/solutions/alexa/alexa-skills-kit/docs/flash-briefing-skill-api-feed-reference).

Create functions for proper marshalling of the JSON and to provide an HTTP Handler for use in a server